### PR TITLE
feat: Add loading screen and favicon

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,15 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <!-- SA Flag Background -->
+    <path d="M0 0H512V170.667H0V0Z" fill="#DE3831"/>
+    <path d="M0 341.333H512V512H0V341.333Z" fill="#0077C8"/>
+    <path d="M0 170.667H512V341.333H0V170.667Z" fill="#FFFFFF"/>
+    <path d="M0 170.667L192 256L0 341.333V170.667Z" fill="#007A4D"/>
+    <path d="M240 256L0 416V96L240 256Z" fill="black"/>
+    <path d="M-28 170.667L164 256L-28 341.333" stroke="#FFB81C" stroke-width="42.667"/>
+    <path d="M512 170.667H0V341.333H512V170.667Z" stroke="white" stroke-width="21.333"/>
+
+    <!-- Meter Dial -->
+    <circle cx="256" cy="256" r="100" fill="#f0f4f8" stroke="#262626" stroke-width="10"/>
+    <path d="M256 256 L 206 170" stroke="#DE3831" stroke-width="10" stroke-linecap="round"/>
+    <path d="M196 316 A 120 120 0 0 1 316 316" stroke="#262626" stroke-width="10" fill="none"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -6,11 +6,16 @@
     <title>The Mzansi Meter - The SA Guessing Game</title>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <!-- Google Ads -->
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1234567890123456"
      crossorigin="anonymous"></script>
 </head>
 <body>
+    <div id="loading-screen">
+        <p>Getting the braai ready...</p>
+        <!-- Optional: Add a CSS spinner animation here -->
+    </div>
     <div id="game-container">
         <!-- Start Screen -->
         <div id="start-screen" class="screen active">

--- a/script.js
+++ b/script.js
@@ -495,3 +495,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
 });
+
+window.onload = function() {
+    document.getElementById('loading-screen').style.display = 'none';
+};

--- a/styles.css
+++ b/styles.css
@@ -399,3 +399,18 @@ body {
     color: #999;
     font-size: 0.75rem;
 }
+
+#loading-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: #f0f4f8;
+    z-index: 1000;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.5rem;
+    font-weight: 700;
+}


### PR DESCRIPTION
This commit introduces a loading screen and a favicon to improve the user experience and professional polish of the application.

- A simple loading screen is displayed while game assets are loading to prevent users on slower connections from seeing broken elements.
- A custom SVG favicon has been added to give the application a unique identity in browser tabs and bookmarks.