### PR TITLE
Fix: Add Firestore index for leaderboard

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,5 +12,8 @@
         "destination": "/index.html"
       }
     ]
+  },
+  "firestore": {
+    "indexes": "firestore.indexes.json"
   }
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,15 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "leaderboard",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "score",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
The leaderboard was failing to load because the Firestore query required a composite index that was not defined. This change adds the necessary index configuration to resolve the issue.

- I created `firestore.indexes.json` to define the index on the 'leaderboard' collection for the 'score' field (descending).
- I updated `firebase.json` to reference the new index file.