### PR TITLE
Fix: Add Firestore rules to display leaderboard

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -14,6 +14,7 @@
     ]
   },
   "firestore": {
+    "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,14 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Allow public read access to the leaderboard, and allow anyone to create a new score
+    // with some basic validation.
+    match /leaderboard/{docId} {
+      allow read: if true;
+      allow create: if request.resource.data.name is string &&
+                       request.resource.data.name.size() <= 3 &&
+                       request.resource.data.score is number &&
+                       request.resource.data.score >= 0;
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces Firestore security rules to allow public read access to the leaderboard collection. This should fix the issue where the leaderboard was not displaying.

The new `firestore.rules` file allows anyone to read the leaderboard data. It also includes a rule to allow creating new scores, with basic validation to ensure data integrity.

The `firebase.json` file has been updated to point to the new rules file, so that these rules are applied on the next Firebase deployment.