### PR TITLE
feat: Implement Daily Challenge mode and leaderboard

### DIFF
--- a/api/getDailySeed.js
+++ b/api/getDailySeed.js
@@ -1,0 +1,72 @@
+// A simple pseudo-random number generator (PRNG) using the LCG formula
+function createSeededRandom(seed) {
+    let state = seed;
+    // LCG parameters
+    const a = 1664525;
+    const c = 1013904223;
+    const m = 2 ** 32;
+
+    return function() {
+        state = (a * state + c) % m;
+        return state / m;
+    };
+}
+
+// Fisher-Yates shuffle algorithm to shuffle an array based on a seeded PRNG
+function shuffleArray(array, seededRandom) {
+    let m = array.length, t, i;
+
+    // While there remain elements to shuffle…
+    while (m) {
+        // Pick a remaining element…
+        i = Math.floor(seededRandom() * m--);
+
+        // And swap it with the current element.
+        t = array[m];
+        array[m] = array[i];
+        array[i] = t;
+    }
+
+    return array;
+}
+
+module.exports = async (req, res) => {
+    try {
+        const TOTAL_QUESTIONS = 101; // As determined from questions.json
+
+        // 1. Generate a daily seed from the current date (UTC)
+        const today = new Date();
+        const year = today.getUTCFullYear();
+        const month = (today.getUTCMonth() + 1).toString().padStart(2, '0');
+        const day = today.getUTCDate().toString().padStart(2, '0');
+        const dateString = `${year}-${month}-${day}`;
+
+        // Create a numeric seed from the date string
+        let seed = 0;
+        for (let i = 0; i < dateString.length; i++) {
+            seed = (seed * 31 + dateString.charCodeAt(i)) & 0xFFFFFFFF; // Keep it a 32-bit integer
+        }
+
+        // 2. Create a seeded random number generator
+        const seededRandom = createSeededRandom(seed);
+
+        // 3. Generate a predictable sequence of numbers
+        const allQuestionIndices = Array.from({ length: TOTAL_QUESTIONS }, (_, i) => i);
+
+        // 4. Shuffle the array of indices using the seeded PRNG
+        const shuffledIndices = shuffleArray(allQuestionIndices, seededRandom);
+
+        // 5. Take the first 10 indices for the daily challenge
+        const dailyQuestions = shuffledIndices.slice(0, 10);
+
+        // 6. Return the JSON response
+        res.setHeader('Content-Type', 'application/json');
+        // Set cache headers - cache for 15 minutes on the client, 1 hour on the CDN
+        res.setHeader('Cache-Control', 'public, max-age=900, s-maxage=3600');
+        res.status(200).json({ dailyQuestions });
+
+    } catch (error) {
+        console.error("Error generating daily seed:", error);
+        res.status(500).json({ error: 'Error generating daily seed' });
+    }
+};

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,16 @@
+const functions = require('firebase-functions');
+const express = require('express');
+const generateImageHandler = require('./generate-image.js');
+const getDailySeedHandler = require('./getDailySeed.js');
+
+const app = express();
+
+// Route requests to the appropriate handlers
+app.get('/generate-image', generateImageHandler);
+app.get('/getDailySeed', getDailySeedHandler);
+
+
+// Expose the Express app as a single Cloud Function.
+// This function will be named 'api' because the file is index.js
+// and it's the only export.
+exports.api = functions.https.onRequest(app);

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "functions",
+  "description": "Cloud Functions for Firebase",
+  "main": "index.js",
+  "dependencies": {
+    "canvas": "^2.11.2",
+    "express": "^4.18.2",
+    "firebase-admin": "^11.8.0",
+    "firebase-functions": "^4.3.1"
+  },
+  "private": true,
+  "engines": {
+    "node": "18"
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -8,10 +8,18 @@
     ],
     "rewrites": [
       {
-        "source": "**",
+        "source": "/api{,/**}",
+        "function": "api"
+      },
+      {
+        "source": "!/api{,/**}",
         "destination": "/index.html"
       }
     ]
+  },
+  "functions": {
+    "source": "api",
+    "runtime": "nodejs18"
   },
   "firestore": {
     "rules": "firestore.rules",

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,5 +10,14 @@ service cloud.firestore {
                        request.resource.data.score is number &&
                        request.resource.data.score >= 0;
     }
+
+    // Allow public read access and validated writes to daily leaderboards
+    match /leaderboard_daily_{date}/{docId} {
+        allow read: if true;
+        allow create: if request.resource.data.name is string &&
+                         request.resource.data.name.size() <= 3 &&
+                         request.resource.data.score is number &&
+                         request.resource.data.score >= 0;
+    }
   }
 }

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
                 <p>The SA Guessing Game</p>
             </div>
             <div class="high-score-display">High Score: <span id="high-score-start">0</span></div>
-            <button id="start-button" class="action-button">Start Game</button>
+            <button id="start-button" class="action-button">Endless Mode</button>
+            <button id="daily-challenge-button" class="action-button">Daily Challenge</button>
             <button id="leaderboard-button" class="action-button secondary">Leaderboard</button>
             <div class="footer-note">🇿🇦 How lekker is your local knowledge? 🇿🇦</div>
         </div>
@@ -109,7 +110,13 @@
 
         <!-- Leaderboard Screen -->
         <div id="leaderboard-screen" class="screen">
-            <h2 id="leaderboard-title">Global Leaderboard</h2>
+            <div id="leaderboard-header">
+                <h2 id="leaderboard-title">Leaderboard</h2>
+                <div id="leaderboard-toggle-buttons">
+                    <button id="show-daily-leaderboard" class="action-button small">Today's</button>
+                    <button id="show-all-time-leaderboard" class="action-button small secondary">All-Time</button>
+                </div>
+            </div>
             <ol id="leaderboard-list"></ol>
             <button id="back-to-start-button" class="action-button">Back</button>
         </div>


### PR DESCRIPTION
This commit introduces a new 'Daily Challenge' game mode.

- Adds a 'Daily Challenge' button to the start screen.
- Creates a new Firebase Function `getDailySeed` in the `api` directory to generate a deterministic set of 10 questions for each day.
- Implements the game logic to fetch these questions and present them in the correct order.
- Adds a separate daily leaderboard, storing scores in a new Firestore collection `leaderboard_daily_YYYY-MM-DD`.
- Updates the leaderboard screen with a toggle to switch between the 'All-Time' and 'Today's' leaderboards.
- Refactors the `api` directory into a standard Firebase Cloud Functions module with an Express server to handle routing, ensuring both the new and existing API endpoints are correctly served.