### PR TITLE
Fix: Refactor daily leaderboard for scalability

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,25 +1,18 @@
 {
   "indexes": [
-    {
-      "collectionGroup": "leaderboard",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "score",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "leaderboard_daily_2025-09-26",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "score",
-          "order": "DESCENDING"
-        }
-      ]
-    }
+    // This array is intentionally left empty.
+    //
+    // The user's initial instructions included a 'COLLECTION_GROUP' index for the 'scores' collection.
+    // However, the provided 'showLeaderboard' function in 'script.js' performs a simple collection query:
+    // `db.collection('daily_leaderboards').doc(dateStr).collection('scores').orderBy('score', 'desc')`
+    // This is NOT a collection group query.
+    //
+    // When attempting to deploy the specified COLLECTION_GROUP index, the `firebase deploy` command fails with the error:
+    // "this index is not necessary, configure using single field index controls"
+    //
+    // This confirms that for the query being used, Firestore's automatic indexing is sufficient.
+    // The deployment succeeds only when this file contains no index definitions.
+    // Therefore, the required indexes are being created and managed automatically by Firestore.
   ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,13 +11,13 @@ service cloud.firestore {
                        request.resource.data.score >= 0;
     }
 
-    // Allow public read access and validated writes to daily leaderboards
-    match /leaderboard_daily_{date}/{docId} {
-        allow read: if true;
-        allow create: if request.resource.data.name is string &&
-                         request.resource.data.name.size() <= 3 &&
-                         request.resource.data.score is number &&
-                         request.resource.data.score >= 0;
+    // Allow public read access and validated writes to the new daily leaderboards structure
+    match /daily_leaderboards/{date}/scores/{scoreId} {
+      allow read: if true;
+      allow create: if request.resource.data.name is string &&
+                       request.resource.data.name.size() <= 3 &&
+                       request.resource.data.score is number &&
+                       request.resource.data.score >= 0;
     }
   }
 }


### PR DESCRIPTION
This commit refactors the Firestore database structure for the daily leaderboard to address a scalability issue. The previous implementation created a new collection for each day, which is not sustainable.

The new structure uses a single `daily_leaderboards` collection. Each day is a document within this collection, and the scores for that day are stored in a `scores` subcollection.

Changes include:
- Updated `script.js` to use the new nested collection path for submitting and fetching scores.
- Updated `firestore.rules` to secure the new `daily_leaderboards/{date}/scores/{scoreId}` path.
- Emptied `firestore.indexes.json` as Firestore's automatic indexing is sufficient for the queries being used, and added a comment explaining this.