### PR TITLE
feat: Integrate AdSense with the correct publisher ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="styles.css">
     <link rel="icon" href="assets/favicon.png" type="image/png">
     <!-- Google Ads -->
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1234567890123456"
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8118267122499622"
      crossorigin="anonymous"></script>
 </head>
 <body>
@@ -84,7 +84,7 @@
                 <small>Advertisement</small>
                 <ins class="adsbygoogle"
                      style="display:block"
-                     data-ad-client="ca-pub-1234567890123456"
+                     data-ad-client="ca-pub-8118267122499622"
                      data-ad-slot="1234567890"
                      data-ad-format="auto"
                      data-full-width-responsive="true"></ins>


### PR DESCRIPTION
This commit updates the AdSense script tag and ad unit in `index.html` to use the correct publisher ID, `ca-pub-8118267122499622`, replacing the placeholder ID.